### PR TITLE
fix: add deploy feature flag to cargo.toml to prevent rust-analyzer errs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,8 @@ version = "0.0.0"
 edition = "2021"
 
 [features]
-default = ["stageleft_devel"]
+default = ["stageleft_devel", "deploy"]
+deploy = []
 stageleft_devel = []
 
 [dependencies]


### PR DESCRIPTION
Rust Analyzer when starting up in the project shows the following error.
```
rust-analyzer Flycheck failed: package 'hydro-template' does not contain feature 'deploy'
Error occurred when running: cargo check --workspace --features deploy
```
Adding the deploy feature to cargo.toml seems to prevent this error from occurring, without affecting builds.